### PR TITLE
remove constraint on ppxlib

### DIFF
--- a/ppx_yojson_conv.opam
+++ b/ppx_yojson_conv.opam
@@ -15,7 +15,7 @@ depends: [
   "ppx_js_style"
   "ppx_yojson_conv_lib"
   "dune"                {>= "2.0.0"}
-  "ppxlib"              {>= "0.15.0" & < "0.18.0"}
+  "ppxlib"              {>= "0.15.0"}
 ]
 synopsis: "[@@deriving] plugin to generate Yojson conversion functions"
 description: "


### PR DESCRIPTION
Hi,

Surprisingly, it seems that ppx_yojson_conv is compatible with ppxlib >= 0.18
I've tested my fork by pinning it locally and it compiles and produces the right results (at least with ppx 0.20.0).

Would it be possible to remove the constraint and publish on opam :) ?
If anything needs to be done before that, I can help.