### PR TITLE
Change dependency ppx js style to dev only

### DIFF
--- a/ppx_yojson_conv.opam
+++ b/ppx_yojson_conv.opam
@@ -13,7 +13,7 @@ build: [
 depends: [
   "ocaml"               {>= "5.1.0"}
   "base"                {>= "v0.17" & < "v0.18"}
-  "ppx_js_style"        {>= "v0.17" & < "v0.18"}
+  "ppx_js_style"        {with-dev-setup & >= "v0.17" & < "v0.18"}
   "ppx_yojson_conv_lib" {>= "v0.17" & < "v0.18"}
   "dune"                {>= "3.11.0"}
   "ppxlib"              {>= "0.28.0"}

--- a/src/dune
+++ b/src/dune
@@ -3,5 +3,5 @@
  (public_name ppx_yojson_conv)
  (kind ppx_deriver)
  (libraries ppxlib ppx_yojson_conv_expander)
- (preprocess
+ (lint
   (pps ppx_js_style)))


### PR DESCRIPTION
This PR changes the application of `ppx_js_style` from a build preprocessor to a linting one.

This makes `ppx_js_style` only required in dev mode, effectively removing it from the transitive deps of `ppx_yojson_conv`.